### PR TITLE
Bump next-offline and use new now.json config

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,16 +2,27 @@
   "version": 2,
   "name": "naterad",
   "alias": "naterad.now.sh",
-  "builds": [{ "src": "package.json", "use": "@now/next" }],
 
-  "routes": [
+  "rewrites": [
     {
-      "src": "^/service-worker.js$",
-      "dest": "/_next/static/service-worker.js",
-      "headers": {
-        "cache-control": "public, max-age=43200, immutable",
-        "Service-Worker-Allowed": "/"
-      }
+      "source": "/service-worker.js",
+      "destination": "/_next/static/service-worker.js"
+    }
+  ],
+
+  "headers": [
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=43200, immutable"
+        },
+        {
+          "key": "Service-Worker-Allowed",
+          "value": "/"
+        }
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "marked": "^0.8.2",
     "next": "^9.3.5",
     "next-mdx-enhanced": "^2.4.0",
-    "next-offline": "^5.0.0",
+    "next-offline": "^5.0.1",
     "prism-react-renderer": "^1.0.2",
     "prism-themes": "^1.4.0",
     "prismjs": "^1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6102,10 +6102,10 @@ next-mdx-enhanced@^2.4.0:
     prebuild-webpack-plugin "1.1.0"
     stringify-object "^3.3.0"
 
-next-offline@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/next-offline/-/next-offline-5.0.0.tgz#bd47a795965aceace38cdb60709c8ef980c49559"
-  integrity sha512-u3w+OCtWX0B1gES8L+mWhf1aPk3t81eGqaeukswnzLgdCVjSrbrMB3YcdoWMf80Vf5k6IcgGNVU2sGZVdqjnUQ==
+next-offline@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/next-offline/-/next-offline-5.0.1.tgz#3c95bf0ce19c5d39ab6a5533cb756b4362cf4072"
+  integrity sha512-zDQ5Acg4mYUXgvXQSbFuripas802R0al/hl0T6W492ZMpnJT8XIGikodjrQafdldZRObcwXt26u1hmtVDVsVZA==
   dependencies:
     copy-webpack-plugin "~5.0.5"
     fs-extra "~8.1.0"


### PR DESCRIPTION
Bump next-offline and use new now.json config

Per updated next-offline example:
* https://github.com/hanford/next-offline/commit/cef3b1a502e76f64987c7ce42f8b611ca937ae2b?diff=split